### PR TITLE
add first_name and last_name to user

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -42,12 +42,12 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   # If you have extra params to permit, append them to the sanitizer.
   def configure_sign_up_params
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:first_name, :last_name])
   end
 
   # If you have extra params to permit, append them to the sanitizer.
   def configure_account_update_params
-    devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:first_name, :last_name])
   end
 
   # The path used after sign up.

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -4,34 +4,60 @@
   <%= render "devise/shared/error_messages", resource: user %>
 
   <div class="flex flex-col my-4">
-      <%= f.label :email, class: "
-      text-md text-gray-700 font-semibold mb-2
-      " %>
-      <%= f.email_field :email, placeholder: "johndoe@email.com", autofocus: true, autocomplete: "email", class: "
-      appearance-none
-      shadow border rounded-md
-      w-full py-2 px-3 leading-tight
-      text-gray-700
-      focus:shadow-outline
-      " %>
+    <%= f.label :first_name, class: "
+    text-md text-gray-700 font-semibold mb-2
+    " %>
+    <%= f.text_field :first_name, placeholder: "johndoe@email.com", required: true, autofocus: true, autocomplete: "email", class: "
+    appearance-none
+    shadow border rounded-md
+    w-full py-2 px-3 leading-tight
+    text-gray-700
+    focus:shadow-outline
+    " %>
   </div>
 
   <div class="flex flex-col my-4">
-      <%= f.label :password, class: "
-      text-md text-gray-700 font-semibold
-      " %>
-      <% if @minimum_password_length %>
-      <p class="italic text-sm text-gray-400 mb-2">
-          (<%= @minimum_password_length %> characters minimum)
-      </p>
-      <% end %>
-      <%= f.password_field :password, placeholder: "*********", autocomplete: "new-password", class: "
-      appearance-none
-      shadow border rounded-md
-      w-full py-2 px-3 leading-tight
-      text-gray-700
-      focus:shadow-outline
-      " %>
+    <%= f.label :last_name, class: "
+    text-md text-gray-700 font-semibold mb-2
+    " %>
+    <%= f.text_field :last_name, placeholder: "johndoe@email.com", required: true, autofocus: true, autocomplete: "email", class: "
+    appearance-none
+    shadow border rounded-md
+    w-full py-2 px-3 leading-tight
+    text-gray-700
+    focus:shadow-outline
+    " %>
+  </div>
+    
+  <div class="flex flex-col my-4">
+    <%= f.label :email, class: "
+    text-md text-gray-700 font-semibold mb-2
+    " %>
+    <%= f.email_field :email, placeholder: "johndoe@email.com", autofocus: true, autocomplete: "email", class: "
+    appearance-none
+    shadow border rounded-md
+    w-full py-2 px-3 leading-tight
+    text-gray-700
+    focus:shadow-outline
+    " %>
+  </div>
+
+  <div class="flex flex-col my-4">
+    <%= f.label :password, class: "
+    text-md text-gray-700 font-semibold
+    " %>
+    <% if @minimum_password_length %>
+    <p class="italic text-sm text-gray-400 mb-2">
+        (<%= @minimum_password_length %> characters minimum)
+    </p>
+    <% end %>
+    <%= f.password_field :password, placeholder: "*********", autocomplete: "new-password", class: "
+    appearance-none
+    shadow border rounded-md
+    w-full py-2 px-3 leading-tight
+    text-gray-700
+    focus:shadow-outline
+    " %>
   </div>
 
   <div class="flex flex-col my-4">
@@ -48,13 +74,13 @@
   </div>
 
   <div class="mt-8">
-      <%= f.submit button_text, class: "
-      w-full py-2 px-4
-      text-white font-bold
-      bg-gray-600 hover:bg-gray-700
-      rounded-lg
-      cursor-pointer
-      transition-all duration-200
-      "%>
+    <%= f.submit button_text, class: "
+    w-full py-2 px-4
+    text-white font-bold
+    bg-gray-600 hover:bg-gray-700
+    rounded-lg
+    cursor-pointer
+    transition-all duration-200
+    "%>
   </div>
 <% end %>

--- a/app/views/admin/users/registrations/new.html.erb
+++ b/app/views/admin/users/registrations/new.html.erb
@@ -3,6 +3,32 @@
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
+  <div class="flex flex-col my-4">
+    <%= f.label :first_name, class: "
+    text-md text-gray-700 font-semibold mb-2
+    " %>
+    <%= f.text_field :first_name, placeholder: "johndoe@email.com", required: true, autofocus: true, autocomplete: "email", class: "
+    appearance-none
+    shadow border rounded-md
+    w-full py-2 px-3 leading-tight
+    text-gray-700
+    focus:shadow-outline
+    " %>
+  </div>
+
+  <div class="flex flex-col my-4">
+    <%= f.label :last_name, class: "
+    text-md text-gray-700 font-semibold mb-2
+    " %>
+    <%= f.text_field :last_name, placeholder: "johndoe@email.com", required: true, autofocus: true, autocomplete: "email", class: "
+    appearance-none
+    shadow border rounded-md
+    w-full py-2 px-3 leading-tight
+    text-gray-700
+    focus:shadow-outline
+    " %>
+  </div>
+
   <div class="field">
     <%= f.label :email %><br />
     <%= f.email_field :email, autofocus: true, autocomplete: "email" %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -15,11 +15,12 @@
         <%= f.label :email, class: "
         text-md text-gray-700 font-semibold mb-2
         " %>
-        <%= f.email_field :email, placeholder: "johndoe@email.com", autofocus: true, autocomplete: "email", class: "
+        <%= f.email_field :email, readonly:true, placeholder: "johndoe@email.com", autofocus: true, autocomplete: "email", class: "
         appearance-none
         shadow border rounded-md
         w-full py-2 px-3 leading-tight
-        text-gray-700
+        text-gray-500
+        bg-gray-100
         focus:shadow-outline
         " %>
       </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -12,10 +12,36 @@
       <%= render "devise/shared/error_messages", resource: resource %>
 
       <div class="flex flex-col my-4">
+        <%= f.label :first_name, class: "
+        text-md text-gray-700 font-semibold mb-2
+        " %>
+        <%= f.text_field :first_name, placeholder: "johndoe@email.com", required: true, autofocus: true, autocomplete: "email", class: "
+        appearance-none
+        shadow border rounded-md
+        w-full py-2 px-3 leading-tight
+        text-gray-700
+        focus:shadow-outline
+        " %>
+      </div>
+
+      <div class="flex flex-col my-4">
+        <%= f.label :last_name, class: "
+        text-md text-gray-700 font-semibold mb-2
+        " %>
+        <%= f.text_field :last_name, placeholder: "johndoe@email.com", required: true, autofocus: true, autocomplete: "email", class: "
+        appearance-none
+        shadow border rounded-md
+        w-full py-2 px-3 leading-tight
+        text-gray-700
+        focus:shadow-outline
+        " %>
+      </div>
+
+      <div class="flex flex-col my-4">
         <%= f.label :email, class: "
         text-md text-gray-700 font-semibold mb-2
         " %>
-        <%= f.email_field :email, placeholder: "johndoe@email.com", autofocus: true, autocomplete: "email", class: "
+        <%= f.email_field :email, placeholder: "johndoe@email.com", required: true, autofocus: true, autocomplete: "email", class: "
         appearance-none
         shadow border rounded-md
         w-full py-2 px-3 leading-tight
@@ -33,7 +59,7 @@
             (<%= @minimum_password_length %> characters minimum)
           </p>
         <% end %>
-        <%= f.password_field :password, placeholder: "*********", autocomplete: "new-password", class: "
+        <%= f.password_field :password, placeholder: "*********", required: true, autocomplete: "new-password", class: "
         appearance-none
         shadow border rounded-md
         w-full py-2 px-3 leading-tight
@@ -46,7 +72,7 @@
         <%= f.label :password_confirmation, class: "
         text-md text-gray-700 font-semibold mb-2
         " %>
-        <%= f.password_field :password_confirmation, placeholder: "*********", autocomplete: "new-password", class: "
+        <%= f.password_field :password_confirmation, placeholder: "*********", required: true, autocomplete: "new-password", class: "
         appearance-none
         shadow border rounded-md
         w-full py-2 px-3 leading-tight

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -105,7 +105,7 @@
           <% if user_signed_in? %>
             <li class="h-full flex items-center justify-center">
               <div class= "px-4 py-5 h-full">
-                Welcome, <%= current_user&.roles&.find_by(name: "admin").nil? ? current_user.email : "Admin" %>!
+                Welcome, <%= current_user&.roles&.find_by(name: "admin").nil? ? current_user.first_name : "Admin" %>!
               </div>
             </li>
             <li class="h-full flex items-center justify-center">

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -244,7 +244,7 @@ Devise.setup do |config|
   # Turn scoped views on. Before rendering "sessions/new", it will first check for
   # "users/sessions/new". It's turned off by default because it's slower if you
   # are using only default views.
-  # config.scoped_views = false
+  config.scoped_views = true
 
   # Configure the default scope given to Warden. By default it's the first
   # devise role declared in your routes (usually :user).

--- a/db/migrate/20211116091657_make_names_required.rb
+++ b/db/migrate/20211116091657_make_names_required.rb
@@ -1,0 +1,6 @@
+class MakeNamesRequired < ActiveRecord::Migration[6.1]
+  def change
+    change_column :users, :first_name, :string, null: false
+    change_column :users, :last_name, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_06_192351) do
+ActiveRecord::Schema.define(version: 2021_11_16_091657) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -67,8 +67,8 @@ ActiveRecord::Schema.define(version: 2021_11_06_192351) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "unconfirmed_email"
-    t.string "first_name"
-    t.string "last_name"
+    t.string "first_name", null: false
+    t.string "last_name", null: false
     t.boolean "confirmed", default: false
     t.boolean "approved", default: false
     t.string "confirmation_token"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,6 +12,8 @@ roles = Role.create([
 
 # TODO: encrypt
 admin = User.create(
+    first_name: "admin",
+    last_name: "admin",
     email: "admin@admin.com",
     password: "password",
     approved: true # admin is automatically approved


### PR DESCRIPTION
Upon sign-up or admin user account creation,
- first_name and last_name are now required fields
- first_name and last_name are now null=false in the schema (don't forget to db:migrate!)
- first_name and last_name were added in required attributes in registrations_controller.rb
- The website now greets the user with his/her first name instead of his/her email!
- give admin a first_name and last_name of "admin"

Note: you'll need to db:reset before running the migration for this to work properly in your end.