### PR TITLE
Search page | stocks show page | lots of cleanup

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,3 +13,12 @@
  *= require_tree .
  *= require_self
  */
+
+.truncate-2-lines {
+    max-height: 3.6em; /* double the size of line-height */
+    line-height: 1.8em;
+    display: block;
+    text-overflow: ellipsis;
+    word-wrap: break-word;
+    overflow: hidden;
+}

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -89,7 +89,7 @@ class Admin::UsersController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def user_params
-      params.require(:user).permit(:email, :password, :password_confirmation, :approved)
+      params.require(:user).permit(:email, :password, :password_confirmation, :approved, :first_name, :last_name)
     end
 
     # remove the need for providing a password when an admin is updating a user

--- a/app/controllers/stocks_controller.rb
+++ b/app/controllers/stocks_controller.rb
@@ -2,10 +2,13 @@ class StocksController < ApplicationController
   before_action :get_api, only: [:create, :search, :show]
 
   def search
+    @toggle1 = "odd"
+    @toggle2 = "odd"
+    @toggle3 = "odd"
     begin
-      @active = @client.stock_market_list(:mostactive)#.sort_by{|stock| stock[:volume]}
-      @gainers = @client.stock_market_list(:gainers)#.sort_by{|stock| stock[:percent_change]}
-      @losers = @client.stock_market_list(:losers)#.sort_by{|stock| stock[:percent_change]}
+      @active = @client.stock_market_list(:mostactive).sort_by{|stock| stock.avg_total_volume}.reverse!
+      @gainers = @client.stock_market_list(:gainers).sort_by{|stock| stock.change_percent}.reverse!
+      @losers = @client.stock_market_list(:losers).sort_by{|stock| stock.change_percent}
     rescue IEX::Errors::SymbolNotFoundError => error
       flash[:alert] = error.message
       redirect_to root_path

--- a/app/controllers/stocks_controller.rb
+++ b/app/controllers/stocks_controller.rb
@@ -2,9 +2,14 @@ class StocksController < ApplicationController
   before_action :get_api, only: [:create, :search, :show]
 
   def search
-    @active = @client.stock_market_list(:mostactive)#.sort_by{|stock| stock[:volume]}
-    @gainers = @client.stock_market_list(:gainers)#.sort_by{|stock| stock[:percent_change]}
-    @losers = @client.stock_market_list(:losers)#.sort_by{|stock| stock[:percent_change]}
+    begin
+      @active = @client.stock_market_list(:mostactive)#.sort_by{|stock| stock[:volume]}
+      @gainers = @client.stock_market_list(:gainers)#.sort_by{|stock| stock[:percent_change]}
+      @losers = @client.stock_market_list(:losers)#.sort_by{|stock| stock[:percent_change]}
+    rescue IEX::Errors::SymbolNotFoundError => error
+      flash[:alert] = error.message
+      redirect_to root_path
+    end
   end
 
   def create

--- a/app/controllers/stocks_controller.rb
+++ b/app/controllers/stocks_controller.rb
@@ -24,7 +24,7 @@ class StocksController < ApplicationController
       @quote = @client.quote(stock_params)
       @company = @client.company(stock_params)
       @logo = @client.logo(stock_params)
-      @news = @client.news(stock_params, 12)
+      @news = @client.news(stock_params, 9)
     rescue IEX::Errors::SymbolNotFoundError => error
       flash[:alert] = error.message
       redirect_to stocks_search_path

--- a/app/controllers/stocks_controller.rb
+++ b/app/controllers/stocks_controller.rb
@@ -2,9 +2,9 @@ class StocksController < ApplicationController
   before_action :get_api, only: [:create, :search, :show]
 
   def search
-    @active = @client.stock_market_list(:mostactive)
-    @gainers = @client.stock_market_list(:gainers)
-    @losers = @client.stock_market_list(:losers)
+    @active = @client.stock_market_list(:mostactive)#.sort_by{|stock| stock[:volume]}
+    @gainers = @client.stock_market_list(:gainers)#.sort_by{|stock| stock[:percent_change]}
+    @losers = @client.stock_market_list(:losers)#.sort_by{|stock| stock[:percent_change]}
   end
 
   def create

--- a/app/controllers/stocks_controller.rb
+++ b/app/controllers/stocks_controller.rb
@@ -16,6 +16,7 @@ class StocksController < ApplicationController
       @quote = @client.quote(stock_params)
       @company = @client.company(stock_params)
       @logo = @client.logo(stock_params)
+      @news = @client.news(stock_params, 12)
     rescue IEX::Errors::SymbolNotFoundError => error
       flash[:alert] = error.message
       redirect_to stocks_search_path

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -64,7 +64,7 @@ class TransactionsController < ApplicationController
     respond_to do |format|
       if @transaction.save
         flash[:notice] = "Transaction was successfully updated."
-        format.html { redirect_to @transaction }
+        format.html { redirect_to transactions_path }
         format.json { render :show, status: :created, location: @transaction }
       else
         format.html { render :new, status: :unprocessable_entity }

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -19,9 +19,14 @@ class TransactionsController < ApplicationController
     @transaction = Transaction.new
     @ticker = params[:ticker]
 
-    @stock_quote = @client.quote(@ticker)
-    @company = @client.company(@ticker)
-    @logo = @client.logo(@ticker)
+    begin
+      @stock_quote = @client.quote(@ticker)
+      @company = @client.company(@ticker)
+      @logo = @client.logo(@ticker)
+    rescue IEX::Errors::SymbolNotFoundError => error
+      flash[:alert] = error.message
+      redirect_to stocks_search_path
+    end
 
     @company_name = @company.company_name
     

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -6,7 +6,12 @@ class WelcomeController < ApplicationController
   def index
     # if not admin, call API
     if current_user&.roles&.find_by(name: "admin").nil?
-      @active5 = @client.stock_market_list(:mostactive)[0..4]
+      begin
+        @active5 = @client.stock_market_list(:mostactive)[0..4]
+      rescue IEX::Errors::SymbolNotFoundError => error
+        flash[:alert] = error.message
+        redirect_to edit_user_registration_path
+      end
     end
   end
 

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,6 +1,6 @@
 <h1 class="mb-3 text-4xl text-gray-700">Users</h1>
 
-<table class="w-full table-auto">
+<table class="w-full table-auto bg-white">
   <thead>
     <tr class="h-10 mb-5 text-sm font-semi-bold uppercase text-gray-600 bg-gray-300 text-center">
       <th class="px-3">ID</th>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -25,7 +25,6 @@
                 <th>Market Value</th>
                 <th>P/L</th>
                 <th>P/L %</th>
-                <th>Actions</th>
             </tr>
         </thead>
         <tbody>
@@ -71,11 +70,6 @@
                     </td>
                     <td class="<%= portfolio_stock.pnl(mkt_price)>0 ? "text-green-500" : "text-red-500" %>">
                         <%= number_to_percentage(portfolio_stock.pnl_perc(mkt_price) * 100, precision: 2) %>
-                    </td>
-                    <td>
-                        <%= link_to portfolio_stock do %>
-                            <i class="fas fa-eye text-gray-600 hover:text-gray-500"></i>
-                        <% end %>
                     </td>
                 </tr>
             <% end %>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -8,7 +8,7 @@
     <table class="
     w-full
     mb-8
-    <%# shadow-md %>
+    bg-white
     ">
         <thead>
             <tr class="
@@ -79,7 +79,7 @@
     <%# transactions %>
     <h2 class="text-3xl mb-3">Transactions</h2>
     <table class="
-    w-full
+    w-full bg-white
     ">
         <thead>
             <tr class="

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -13,18 +13,18 @@
         <thead>
             <tr class="
             h-10
-            text-sm font-semi-bold uppercase text-gray-600
+            text-sm font-semibold uppercase text-gray-600
             bg-gray-200 text-left
             ">
                 <th>
                     <span class="ml-5">Stock</span>
                 </th>
-                <th>Market Price</th>
-                <th>Average Price</th>
-                <th>Shares</th>
-                <th>Market Value</th>
-                <th>P/L</th>
-                <th>P/L %</th>
+                <th class="text-center p-2">Market Price</th>
+                <th class="text-center p-2">Average Price</th>
+                <th class="text-center p-2">Shares</th>
+                <th class="text-center p-2">Market Value</th>
+                <th class="text-center p-2">P/L</th>
+                <th class="text-center p-2">P/L %</th>
             </tr>
         </thead>
         <tbody>
@@ -53,22 +53,22 @@
                             </div>
                         </div>
                     </td>
-                    <td>
+                    <th class="text-center p-2 font-normal">
                         <%= number_to_currency(mkt_price) %>
                     </td>
-                    <td>
+                    <th class="text-center p-2 font-normal">
                         <%= number_to_currency(portfolio_stock.average_price) %>
                     </td>
-                    <td>
+                    <th class="text-center p-2 font-normal">
                         <%= portfolio_stock.shares %>
                     </td>
-                    <td>
+                    <th class="text-center p-2 font-normal">
                         <%= number_to_currency(portfolio_stock.market_price_total(mkt_price)) %>
                     </td>
-                    <td class="<%= portfolio_stock.pnl(mkt_price)>0 ? "text-green-500" : "text-red-500" %>">
+                    <td class="text-center p-2 <%= portfolio_stock.pnl(mkt_price)>0 ? "text-green-500" : "text-red-500" %>">
                         <%= number_to_currency(portfolio_stock.pnl(mkt_price)) %>
                     </td>
-                    <td class="<%= portfolio_stock.pnl(mkt_price)>0 ? "text-green-500" : "text-red-500" %>">
+                    <td class=" text-center p-2 <%= portfolio_stock.pnl(mkt_price)>0 ? "text-green-500" : "text-red-500" %>">
                         <%= number_to_percentage(portfolio_stock.pnl_perc(mkt_price) * 100, precision: 2) %>
                     </td>
                 </tr>
@@ -84,16 +84,16 @@
         <thead>
             <tr class="
             h-10
-            text-sm font-semi-bold uppercase text-gray-600
+            text-sm font-semibold uppercase text-gray-600
             bg-gray-200 text-left
             ">
                 <th>
                     <span class="ml-5">Action</span>
                 </th>
-                <th>Total Price</th>
-                <th>Shares</th>
-                <th>Average Price</th>
-                <th>Current Price</th>
+                <th class="text-center p-2">Total Price</th>
+                <th class="text-center p-2">Shares</th>
+                <th class="text-center p-2">Average Price</th>
+                <th class="text-center p-2">Current Price</th>
             </tr>
         </thead>
         <tbody>
@@ -118,16 +118,16 @@
                         </p>
                         </div>
                     </td>
-                    <td>
+                    <th class="text-center p-2 font-normal">
                         <%= number_to_currency(transaction.price_per_share * transaction.shares) %>
                     </td>
-                    <td>
+                    <th class="text-center p-2 font-normal">
                         <%= transaction.shares %>
                     </td>
-                    <td>
+                    <th class="text-center p-2 font-normal">
                         <%= number_to_currency(transaction.price_per_share) %>
                     </td>
-                    <td>
+                    <th class="text-center p-2 font-normal">
                         <%= number_to_currency(mkt_price) %>
                     </td>
                 </tr>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -161,6 +161,7 @@
     flex flex-col
     flex-grow
     <%= request.path == "/" ? "" : "px-24 mt-9" %>
+    relative
     ">
       <%# notices %>
       <% if notice %>

--- a/app/views/shared/_notice_alert.html.erb
+++ b/app/views/shared/_notice_alert.html.erb
@@ -1,11 +1,11 @@
 <%= javascript_pack_tag 'notices' %>
 <div class="
 flex justify-center items-center self-center
-w-full px-8 py-4
-rounded-md shadow 
+w-4/5 px-24 py-6
+<%= request.path == "/" ? "mt-9" : "" %>
+rounded-md shadow
 bg-red-200 text-red-800
-mb-6
-relative
+absolute z-50
 notice
 ">
     <%= alert %>

--- a/app/views/shared/_notice_notice.html.erb
+++ b/app/views/shared/_notice_notice.html.erb
@@ -1,11 +1,11 @@
 <%= javascript_pack_tag 'notices' %>
 <div class="
 flex justify-center items-center self-center
-w-full px-8 py-4
+w-4/5 px-24 py-6
+<%= request.path == "/" ? "mt-9" : "" %>
 rounded-md shadow
 bg-green-200 text-green-800
-mb-6
-relative
+absolute z-50
 notice
 ">
     <%= notice %>

--- a/app/views/stocks/search.html.erb
+++ b/app/views/stocks/search.html.erb
@@ -1,89 +1,135 @@
-<h1 class="pb-2">Search Stock Ticker<h1>
-<%= form_with method: :post, url: stocks_search_path, class: "pb-10", local: true do |f| %>
-  <%= f.text_field :ticker, class: "border border-solid border-gray-700 py-1 px-2" %>
-  <%= f.submit "Search", class: "bg-gray-700 hover:bg-gray-500 transition-all duration-200 cursor-pointer px-3 py-1 text-white rounded-sm" %>
-<% end %>
+<div class="
+w-full h-full
+">
+  <%# header %>
+  <h1 class="text-4xl mb-3">Markets</h1>
 
-<div class="flex flex-row flex-wrap justify-around"> 
+  <%# searcn %>
+  <%= form_with method: :post, url: stocks_search_path, class: "pb-10", local: true do |f| %>
+    <div class="
+    flex justify-center items-center
+    shadow border rounded-md
+    text-gray-700
+    focus:shadow-outline
+    leading-tight
+    w-1/4
+    ">
+      <%= button_tag type: 'submit', class: "" do %>
+        <div class="py-2 px-3">
+          <i class="fas fa-search"></i>
+        </div>
+      <% end  %>
+      <%= f.text_field :ticker, required: true, placeholder: "Search Stock Ticker", class: "
+      appearance-none
+      w-full py-2 px-3
+      rounded-r-md
+      " %>
+    </div>
+  <% end %>
 
-  <div>
-    <h2 class="text-center text-xl mb-2"><b>Most Active</b></h2>
-
-    <table>
-      <thead>
-        <tr class="h-10 text-sm font-semi-bold uppercase text-gray-600 bg-gray-200 text-center">
-          <th>Stock</th>
-          <th>Volume</th>
-          <th>Last</th>
-          <th>% Change</th>
-          <th class="px-2">Change</th>
-        </tr>
-      </thead>
-
-      <tbody>
-        <% @active.each do | act | %> 
-          <tr>
-            <td class="text-center p-2"><%= act.symbol %></td>
-            <td class="text-center p-2"><%= number_with_delimiter(act.avg_total_volume, :delimeter => ',') %></td>
-            <td class="text-center p-2"><%= number_to_currency(act.latest_price) %></td>
-            <td class="text-center p-2"><%= act.change_percent_s %></td>
-            <td class="text-center p-2"><%= act.change %></td>
+  <%# top stocks %>
+  <div class="flex flex-col flex-wrap justify-around"> 
+    <%# most active %>
+    <div class="w-full mb-6">
+      <h2 class="text-3xl mb-3">Most Active</h2>
+      <table class="w-full">
+        <thead>
+          <tr class="h-10 text-sm font-semi-bold uppercase text-gray-600 bg-gray-200 text-center">
+            <th>Stock</th>
+            <th>Volume</th>
+            <th>Last</th>
+            <th>Change</th>
+            <th>% Change</th>
           </tr>
-        <% end %>
-
-      </tbody>
-    </table>
-  </div>
+        </thead>
+        <tbody>
+          <% @active.each do | act | %> 
+            <tr>
+              <td class="text-center p-2">
+                <%= act.symbol %>
+              </td>
+              <td class="text-center p-2">
+                <%= number_with_delimiter(act.avg_total_volume, :delimeter => ',') %>
+              </td>
+              <td class="text-center p-2 <%= act.change>=0 ? "text-green-500" : "text-red-500" %>">
+                <%= number_to_currency(act.latest_price) %>
+              </td>
+              <td class="text-center p-2 <%= act.change>=0 ? "text-green-500" : "text-red-500" %>">
+                <%= act.change %>
+              </td>
+              <td class="text-center p-2 <%= act.change>=0 ? "text-green-500" : "text-red-500" %>">
+                <%= act.change_percent_s %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
     
-    
-  <div>
-    <h2 class="text-center text-xl mb-2"><b>Top Gainers</b></h2>
-    <table>
-      <thead>
-        <tr class="h-10 text-sm font-semi-bold uppercase text-gray-600 bg-gray-200 text-center">
-          <th>Stock</th>
-          <th>Last</th>
-          <th>Change</th>
-          <th class="px-2">% Change</th>
-        </tr>
-      </thead>
-      
-      <tbody>
-        <% @gainers.each do | gain | %>
-          <tr>
-            <td class="text-center p-2"> <%= gain.symbol %> </td> 
-            <td class="text-center p-2"> <%= number_to_currency(gain.latest_price) %></td>
-            <td class="text-center p-2"> <%= gain.change %> </td>
-            <td class="text-center p-2"> <%= gain.change_percent_s %> </td>
+    <%# top gainers %>
+    <div class="w-full mb-6">
+      <h2 class="text-3xl mb-3">Top Gainers</h2>
+      <table class="w-full">
+        <thead>
+          <tr class="h-10 text-sm font-semi-bold uppercase text-gray-600 bg-gray-200 text-center">
+            <th>Stock</th>
+            <th>Last</th>
+            <th>Change</th>
+            <th>% Change</th>
           </tr>
-        <% end %>
-      </tbody>
-    </table>
-  </div>
+        </thead>
+        <tbody>
+          <% @gainers.each do | gain | %>
+            <tr>
+              <td class="text-center p-2">
+                <%= gain.symbol %>
+              </td> 
+              <td class="text-center p-2 <%= gain.change>=0 ? "text-green-500" : "text-red-500" %>">
+                <%= number_to_currency(gain.latest_price) %>
+              </td>
+              <td class="text-center p-2 <%= gain.change>=0 ? "text-green-500" : "text-red-500" %>">
+                <%= gain.change %>
+              </td>
+              <td class="text-center p-2 <%= gain.change>=0 ? "text-green-500" : "text-red-500" %>">
+                <%= gain.change_percent_s %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
 
-  <div>
-    <h2 class="text-center text-xl mb-2"><b>Top Losers</b></h2>
-    <table>
-      <thead>
-        <tr class="h-10 text-sm font-semi-bold uppercase text-gray-600 bg-gray-200 text-center">
-          <th>Stock</th>
-          <th>Last</th>
-          <th>Change</th>
-          <th class="px-2">% Change</th>
-        </tr>
-      </thead>
-
-      <tbody>
-        <% @losers.each do | lose | %>
-          <tr>
-            <td class="text-center p-2"> <%= lose.symbol %> </td>
-            <td class="text-center p-2"> <%= number_to_currency(lose.latest_price) %> </td>
-            <td class="text-center p-2"> <%= lose.change %> </td>
-            <td class="text-center p-2"> <%= lose.change_percent_s %> </td>
+    <%# top losers %>
+    <div class="w-full mb-6">
+      <h2 class="text-3xl mb-3">Top Losers</h2>
+      <table class="w-full">
+        <thead>
+          <tr class="h-10 text-sm font-semi-bold uppercase text-gray-600 bg-gray-200 text-center">
+            <th>Stock</th>
+            <th>Last</th>
+            <th>Change</th>
+            <th class="px-2">% Change</th>
           </tr>
-        <% end %>
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          <% @losers.each do | lose | %>
+            <tr>
+              <td class="text-center p-2">
+                <%= lose.symbol %>
+              </td>
+              <td class="text-center p-2 <%= gain.change>=0 ? "text-green-500" : "text-red-500" %>">
+                <%= number_to_currency(lose.latest_price) %>
+              </td>
+              <td class="text-center p-2 <%= gain.change>=0 ? "text-green-500" : "text-red-500" %>">
+                <%= lose.change %>
+              </td>
+              <td class="text-center p-2 <%= gain.change>=0 ? "text-green-500" : "text-red-500" %>">
+                <%= lose.change_percent_s %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
   </div>
-
-</div> 
+</div>

--- a/app/views/stocks/search.html.erb
+++ b/app/views/stocks/search.html.erb
@@ -44,12 +44,13 @@ w-full h-full
         </thead>
         <tbody>
           <% @active.each do | act | %> 
-            <tr>
-              <td class="text-center p-2">
+            <tr class="<%= @toggle1 == "odd" ? "" : "bg-gray-200" %> h-16">
+              <% @toggle1 = (@toggle1 == "odd" ? "even" : "odd") %>
+              <td class="text-center p-2 font-semibold">
                 <%= act.symbol %>
               </td>
               <td class="text-center p-2">
-                <%= number_with_delimiter(act.avg_total_volume, :delimeter => ',') %>
+                <%= number_to_currency(act.avg_total_volume, :delimeter => ',') %>
               </td>
               <td class="text-center p-2 <%= act.change>=0 ? "text-green-500" : "text-red-500" %>">
                 <%= number_to_currency(act.latest_price) %>
@@ -80,8 +81,9 @@ w-full h-full
         </thead>
         <tbody>
           <% @gainers.each do | gain | %>
-            <tr>
-              <td class="text-center p-2">
+            <tr class="<%= @toggle2 == "odd" ? "" : "bg-gray-200" %> h-16">
+              <% @toggle2 = (@toggle2 == "odd" ? "even" : "odd") %>
+              <td class="text-center p-2 font-semibold">
                 <%= gain.symbol %>
               </td> 
               <td class="text-center p-2 <%= gain.change>=0 ? "text-green-500" : "text-red-500" %>">
@@ -113,8 +115,9 @@ w-full h-full
         </thead>
         <tbody>
           <% @losers.each do | lose | %>
-            <tr>
-              <td class="text-center p-2">
+            <tr class="<%= @toggle3 == "odd" ? "" : "bg-gray-200" %> h-16">
+              <% @toggle3 = (@toggle3 == "odd" ? "even" : "odd") %>
+              <td class="text-center p-2 font-semibold">
                 <%= lose.symbol %>
               </td>
               <td class="text-center p-2 <%= lose.change>=0 ? "text-green-500" : "text-red-500" %>">

--- a/app/views/stocks/search.html.erb
+++ b/app/views/stocks/search.html.erb
@@ -34,7 +34,7 @@ w-full h-full
       <h2 class="text-3xl mb-3">Most Active</h2>
       <table class="w-full bg-white">
         <thead>
-          <tr class="h-10 text-sm font-semi-bold uppercase text-gray-600 bg-gray-200 text-center">
+          <tr class="h-10 text-sm font-semibold uppercase text-gray-600 bg-gray-200 text-center">
             <th>Stock</th>
             <th>Volume</th>
             <th>Last</th>
@@ -72,7 +72,7 @@ w-full h-full
       <h2 class="text-3xl mb-3">Top Gainers</h2>
       <table class="w-full bg-white">
         <thead>
-          <tr class="h-10 text-sm font-semi-bold uppercase text-gray-600 bg-gray-200 text-center">
+          <tr class="h-10 text-sm font-semibold uppercase text-gray-600 bg-gray-200 text-center">
             <th>Stock</th>
             <th>Last</th>
             <th>Change</th>

--- a/app/views/stocks/search.html.erb
+++ b/app/views/stocks/search.html.erb
@@ -32,7 +32,7 @@ w-full h-full
     <%# most active %>
     <div class="w-full mb-6">
       <h2 class="text-3xl mb-3">Most Active</h2>
-      <table class="w-full">
+      <table class="w-full bg-white">
         <thead>
           <tr class="h-10 text-sm font-semi-bold uppercase text-gray-600 bg-gray-200 text-center">
             <th>Stock</th>
@@ -69,7 +69,7 @@ w-full h-full
     <%# top gainers %>
     <div class="w-full mb-6">
       <h2 class="text-3xl mb-3">Top Gainers</h2>
-      <table class="w-full">
+      <table class="w-full bg-white">
         <thead>
           <tr class="h-10 text-sm font-semi-bold uppercase text-gray-600 bg-gray-200 text-center">
             <th>Stock</th>
@@ -102,7 +102,7 @@ w-full h-full
     <%# top losers %>
     <div class="w-full mb-6">
       <h2 class="text-3xl mb-3">Top Losers</h2>
-      <table class="w-full">
+      <table class="w-full bg-white">
         <thead>
           <tr class="h-10 text-sm font-semi-bold uppercase text-gray-600 bg-gray-200 text-center">
             <th>Stock</th>
@@ -117,13 +117,13 @@ w-full h-full
               <td class="text-center p-2">
                 <%= lose.symbol %>
               </td>
-              <td class="text-center p-2 <%= gain.change>=0 ? "text-green-500" : "text-red-500" %>">
+              <td class="text-center p-2 <%= lose.change>=0 ? "text-green-500" : "text-red-500" %>">
                 <%= number_to_currency(lose.latest_price) %>
               </td>
-              <td class="text-center p-2 <%= gain.change>=0 ? "text-green-500" : "text-red-500" %>">
+              <td class="text-center p-2 <%= lose.change>=0 ? "text-green-500" : "text-red-500" %>">
                 <%= lose.change %>
               </td>
-              <td class="text-center p-2 <%= gain.change>=0 ? "text-green-500" : "text-red-500" %>">
+              <td class="text-center p-2 <%= lose.change>=0 ? "text-green-500" : "text-red-500" %>">
                 <%= lose.change_percent_s %>
               </td>
             </tr>

--- a/app/views/stocks/show.html.erb
+++ b/app/views/stocks/show.html.erb
@@ -1,18 +1,45 @@
-<div class="flex justify-between"> 
-  <div class="flex">  
-    <img src="<%= @logo.url %>" alt="Stock Logo" width="62" height="auto" class="rounded-sm">
+<div class="w-full h-full">
+  <%# stock banner %>
+  <div class="flex justify-between"> 
+    <div class="flex">  
+      <img src="<%= @logo.url %>" alt="Stock Logo" width="62" height="auto" class="rounded-sm">
 
-    <div class="ml-4">
-      <h1> 
-        <span class="text-2xl font-bold"> <%= @company.symbol %> </span> | 
-        <span class="text-sm"> <%= @company.company_name %> </span>
-      </h1>
-      <p> 
-        <span class="text-2xl mr-2"> <%= number_to_currency(@quote.latest_price) %> </span> 
-        <span class="text-sm <%= @quote.change >= 0 ? "text-green-500" : "text-red-500" %> "> <%= @quote.change %>  (<%= @quote.change_percent_s %>) </span>
-      </p>
+      <div class="ml-4">
+        <h1> 
+          <span class="text-2xl font-bold"> <%= @company.symbol %> </span> | 
+          <span class="text-sm"> <%= @company.company_name %> </span>
+        </h1>
+        <p> 
+          <span class="text-2xl mr-2"> <%= number_to_currency(@quote.latest_price) %> </span> 
+          <span class="text-sm <%= @quote.change >= 0 ? "text-green-500" : "text-red-500" %> "> <%= @quote.change %>  (<%= @quote.change_percent_s %>) </span>
+        </p>
+      </div>
     </div>
+
+    <%= link_to new_transaction_path, class:"
+    flex justify-center items-center
+    w-36 py-1 px-4
+    text-white font-bold
+    bg-green-600 hover:bg-green-700
+    rounded-lg
+    cursor-pointer
+    transition-all duration-200
+    " do %>
+      Trade
+    <% end %>
   </div>
 
-  <%= link_to new_transaction_path, class: "my-2 py-3 px-5 text-white bg-green-600 hover:bg-green-700 rounded-lg cursor-pointer transition-all duration-200" do %> Trade <% end %>
-</div> 
+  <%# line %>
+  <hr class="my-6 border-gray-300">
+
+  <%# news %>
+  <div class="
+  flex flex-wrap justify-evenly
+  w-full px-24 py-9
+  ">
+    <% @news.each do |article| %>
+      <%# news article %>
+      <%= render 'welcome/news_article', article: article %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/transactions/index.html.erb
+++ b/app/views/transactions/index.html.erb
@@ -1,7 +1,7 @@
 <div class="w-full h-full">
   <h1 class="text-4xl mb-3">Transactions</h1>
   <table class="
-  w-full
+  w-full bg-white
   ">
     <thead>
       <tr class="

--- a/app/views/transactions/index.html.erb
+++ b/app/views/transactions/index.html.erb
@@ -6,16 +6,16 @@
     <thead>
       <tr class="
       h-10
-      text-sm font-semi-bold uppercase text-gray-600
+      text-sm font-semibold uppercase text-gray-600
       bg-gray-200 text-left
       ">
         <th>
-          <span class="ml-5">Action</span>
+          <span class="ml-8">Action</span>
         </th>
-        <th>Total Price</th>
-        <th>Shares</th>
-        <th>Average Price</th>
-        <th>Current Price</th>
+        <th class="text-center p-2">Total Price</th>
+        <th class="text-center p-2">Shares</th>
+        <th class="text-center p-2">Average Price</th>
+        <th class="text-center p-2">Current Price</th>
       </tr>
     </thead>
     <tbody>
@@ -28,7 +28,7 @@
           <td class="
           flex items-center
           h-16
-          px-5
+          px-8
           ">
             <%= image_tag @client.logo(transaction.stock).url, class: "h-4/5" %>
             <div class="ml-3 flex flex-col">
@@ -40,16 +40,16 @@
               </p>
             </div>
           </td>
-          <td>
+          <td class="text-center p-2">
             <%= number_to_currency(transaction.price_per_share * transaction.shares) %>
           </td>
-          <td>
+          <td class="text-center p-2">
             <%= transaction.shares %>
           </td>
-          <td>
+          <td class="text-center p-2">
             <%= number_to_currency(transaction.price_per_share) %>
           </td>
-          <td>
+          <td class="text-center p-2">
             <%= number_to_currency(mkt_price) %>
           </td>
         </tr>

--- a/app/views/welcome/_news_article.html.erb
+++ b/app/views/welcome/_news_article.html.erb
@@ -11,7 +11,7 @@ w-1/4 h-96 mx-6 mb-10
         <div class="text-gray-600 text-sm mb-2">
             <%= article.datetime.strftime("%d/%m/%Y %I:%M %p") %>
         </div>
-        <div class="font-bold mb-2">
+        <div class="font-bold mb-2 truncate-2-lines"> <%# TODO: use tailwindcss-line-clamp plugin %>
             <%= link_to article.url do %>
                 <%= article.headline %>
             <% end  %>

--- a/app/views/welcome/all_transactions.html.erb
+++ b/app/views/welcome/all_transactions.html.erb
@@ -1,7 +1,7 @@
 <div class="w-full h-full">
   <h1 class="text-4xl mb-3">All Transactions</h1>
   <table class="
-  w-full
+  w-full bg-white
   ">
     <thead>
       <tr class="

--- a/app/views/welcome/all_transactions.html.erb
+++ b/app/views/welcome/all_transactions.html.erb
@@ -6,17 +6,17 @@
     <thead>
       <tr class="
       h-10
-      text-sm font-semi-bold uppercase text-gray-600
+      text-sm font-semibold uppercase text-gray-600
       bg-gray-200 text-left
       ">
-        <th>
+        <th class="text-center p-2">
           <span class="ml-5">User ID</span>
         </th>
         <th>Action</th>
-        <th>Total Price</th>
-        <th>Shares</th>
-        <th>Average Price</th>
-        <th>Current Price</th>
+        <th class="text-center p-2">Total Price</th>
+        <th class="text-center p-2">Shares</th>
+        <th class="text-center p-2">Average Price</th>
+        <th class="text-center p-2">Current Price</th>
       </tr>
     </thead>
     <tbody>
@@ -26,7 +26,7 @@
         <%= @toggle == "odd" ? "" : "bg-gray-200" %>
         ">
           <% @toggle = (@toggle == "odd" ? "even" : "odd") %>
-          <td class="px-5">
+          <td class="px-5 text-center">
             <%= link_to admin_user_path(transaction.user_id) do %>
               <%= transaction.user_id %>
             <% end %>
@@ -45,16 +45,16 @@
               </p>
             </div>
           </td>
-          <td>
+          <th class="text-center p-2 font-normal">
             <%= number_to_currency(transaction.price_per_share * transaction.shares) %>
           </td>
-          <td>
+          <th class="text-center p-2 font-normal">
             <%= transaction.shares %>
           </td>
-          <td>
+          <th class="text-center p-2 font-normal">
             <%= number_to_currency(transaction.price_per_share) %>
           </td>
-          <td>
+          <th class="text-center p-2 font-normal">
             <%= number_to_currency(mkt_price) %>
           </td>
         </tr>

--- a/app/views/welcome/approvals.html.erb
+++ b/app/views/welcome/approvals.html.erb
@@ -1,7 +1,7 @@
 <div> 
   <h1 class="mb-3 text-4xl text-gray-700">Unapproved Users</h1>
 
-  <table class="w-full">
+  <table class="w-full bg-white">
     <thead>
       <tr class="h-10 mb-5 text-sm font-semi-bold uppercase text-gray-600 bg-gray-300 text-center">
         <th class="px-3">ID</th>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -143,7 +143,6 @@
     <%# news articles %>
     <div class="
     flex flex-wrap justify-evenly
-    bg-white
     w-full px-24 py-9
     ">
         <% @active5.each do |stock| %>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -73,9 +73,9 @@
     <%# hero banner %>
     <div id="home-banner" class="
     flex flex-col justify-between items-center
-    w-full h-96 px-24 py-9
+    w-full px-24 py-9
     text-white
-    ">  
+    " style="height: 28rem;">
         <%# call to action %>
         <div class="
         flex flex-col w-full mt-7

--- a/app/views/welcome/portfolio.html.erb
+++ b/app/views/welcome/portfolio.html.erb
@@ -6,18 +6,18 @@
         <thead>
             <tr class="
             h-10
-            text-sm font-semi-bold uppercase text-gray-600
+            text-sm font-semibold uppercase text-gray-600
             bg-gray-200 text-left
             ">
                 <th>
-                    <span class="ml-5">Stock</span>
+                    <span class="ml-8">Stock</span>
                 </th>
-                <th>Market Price</th>
-                <th>Average Price</th>
-                <th>Shares</th>
-                <th>Market Value</th>
-                <th>P/L</th>
-                <th>P/L %</th>
+                <th class="text-center p-2">Market Price</th>
+                <th class="text-center p-2">Average Price</th>
+                <th class="text-center p-2">Shares</th>
+                <th class="text-center p-2">Market Value</th>
+                <th class="text-center p-2">P/L</th>
+                <th class="text-center p-2">P/L %</th>
             </tr>
         </thead>
         <tbody>
@@ -30,7 +30,7 @@
                     <td class="
                     flex items-center
                     h-16
-                    px-5
+                    px-8
                     ">
                         <%= image_tag @client.logo(portfolio_stock.stock).url, class: "h-4/5" %>
                         <div class="ml-3">
@@ -46,16 +46,16 @@
                             </div>
                         </div>
                     </td>
-                    <td>
+                    <th class="text-center p-2">
                         <%= number_to_currency(mkt_price) %>
                     </td>
-                    <td>
+                    <th class="text-center p-2">
                         <%= number_to_currency(portfolio_stock.average_price) %>
                     </td>
-                    <td>
+                    <th class="text-center p-2">
                         <%= portfolio_stock.shares %>
                     </td>
-                    <td>
+                    <th class="text-center p-2">
                         <%= number_to_currency(portfolio_stock.market_price_total(mkt_price)) %>
                     </td>
                     <td class="<%= portfolio_stock.pnl(mkt_price)>0 ? "text-green-500" : "text-red-500" %>">

--- a/app/views/welcome/portfolio.html.erb
+++ b/app/views/welcome/portfolio.html.erb
@@ -1,7 +1,7 @@
 <div class="w-full h-full">
     <h1 class="text-4xl mb-3">Portfolio</h1>
     <table class="
-    w-full
+    w-full bg-white
     ">
         <thead>
             <tr class="

--- a/app/views/welcome/portfolio.html.erb
+++ b/app/views/welcome/portfolio.html.erb
@@ -18,7 +18,6 @@
                 <th>Market Value</th>
                 <th>P/L</th>
                 <th>P/L %</th>
-                <th>Actions</th>
             </tr>
         </thead>
         <tbody>
@@ -64,11 +63,6 @@
                     </td>
                     <td class="<%= portfolio_stock.pnl(mkt_price)>0 ? "text-green-500" : "text-red-500" %>">
                         <%= number_to_percentage(portfolio_stock.pnl_perc(mkt_price) * 100, precision: 2) %>
-                    </td>
-                    <td>
-                        <%= link_to portfolio_stock do %>
-                            <i class="fas fa-eye text-gray-600 hover:text-gray-500"></i>
-                        <% end %>
                     </td>
                 </tr>
             <% end %>


### PR DESCRIPTION
*Search Page*
- restyle search box 
  - similar to other text_fields in app
  - button is now a magnifying class icon that's clickable (submits)
- tabes are now uniform in width and are stacked on top of each other
- tables are styled like other tables in the site (colored gains, losses, etc.)
- tables are now logically ordered (active stocks arranged by volume, gains/losses assigned by change_percentage)

*Stocks Show Page*
- horizontal line added to separate stock banner and news
- added news cards

*Clean Up*
- homepage background color fixed
- news cards headlines truncated to fit card
- API calls in controllers are now wrapped in begin-rescue
- first_name and last_name added to admin user creation params (no more errors!)
- additional action column on portfolio pages now removed
- table default bg-color now white, to contrast gray background
- all tables made more consistent (non-stockaction columns centered)
- make notices not inline
- extend home-page banner by 4rem
- redirect users to transactions page after transaction creation (used to show specific transaction created)